### PR TITLE
parallelise xval replicates with foreach()

### DIFF
--- a/code/conStruct/DESCRIPTION
+++ b/code/conStruct/DESCRIPTION
@@ -12,12 +12,14 @@ Depends:
     rstan (>= 2.15.1)
 Imports:
     caroline,
-    gtools
+    gtools,
+    foreach
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
 Suggests:
     knitr,
-    rmarkdown
+    rmarkdown,
+    doParallel
 VignetteBuilder: knitr

--- a/code/conStruct/R/model.comparison.R
+++ b/code/conStruct/R/model.comparison.R
@@ -47,13 +47,13 @@
 #'		"testing" data partitions of that replicate for the nonspatial model for
 #' 		each value of K specified in \code{K}.
 #' }
+#' @imports foreach
 #'@export
 x.validation <- function(train.prop = 0.9, n.reps, K, freqs, geoDist, coords, prefix, n.iter, make.figs = FALSE, save.files = FALSE){
-	models <- compile.models()
-    x.val <- lapply(1:n.reps, 
-    				function(i) {
-        				x.validation.rep(models, 
-        								 rep.no = i, 
+    require(foreach)
+    x.val <- foreach(i=1:n.reps, .export=ls()) %dopar {
+        	conStruct:::x.validation.rep(conStruct:::compile.models(),
+                                         rep.no = i, 
         								 train.prop, 
         								 K, 
         								 freqs, 
@@ -62,8 +62,8 @@ x.validation <- function(train.prop = 0.9, n.reps, K, freqs, geoDist, coords, pr
         								 prefix, 
         								 n.iter, 
         								 make.figs, 
-        								 save.files)        				
-    		 })
+        								 save.files)
+    }
     names(x.val) <- paste0("rep_", 1:n.reps)
     x.val <- lapply(x.val, standardize.xvals)
     return(x.val)


### PR DESCRIPTION
NB: work in progress -- take this PR as asking permission/advice about this.

This parallelises the outer loop of the x.validation function, over cross-validation replicates. This isn't as efficient as it could be, as we can/should parallelise the inner loops combined with the outer loop, in essence running each conStruct MCMC model in parallel. This requires re-factoring the x.validation function & the x.validation.rep functions together.

It would look like:

```
all.models = foreach(xval.rep=1:n.reps) %:%
foreach(K=K) %:%
foreach(spatial=c(T,F)) %dopar% {
   rstan::sampling(...)
}

 # process/standardise replicates etc, as per x.validation.rep & standardize.xvals
```

Then, users would do something like:

```
library(foreach)
library(doParallel)
cl <- makeParallelCluster(16)
registerDoParallel(cl)

construct::x.validation(...)
```

and their cross-validations would happen in parallel. 