### PR TITLE
Update plot.output.R

### DIFF
--- a/R/plot.output.R
+++ b/R/plot.output.R
@@ -61,7 +61,7 @@ make.all.the.plots <- function(conStruct.results,data.block,prefix,layer.colors=
 		stop("\nyou must specify conStruct results across all chains\ni.e. from conStruct.results rather than conStruct.results[[1]]\n\n")
 	}
 	if(!is.null(layer.colors)){
-		if(length(layer.colors!=data.block$K)){
+		if(length(layer.colors)!=data.block$K){
 			stop("\nyou must specify one color per layer\n\n")
 		}
 	} else {


### PR DESCRIPTION
Dear GBradburg,
I am using conStruct, and the function "make.all.the.plots" complains that the number of colors is always wrong when I specify a different "layer.colors".
I think the problem may be in the actual code of plot.output.R, where the length of layer.colors is compared to data.block$K. As I understand it, the "if" statement evaluates always true as it is coded. I proposed a change, please see if it makes sense to you.

Best regards,
Andrea Fulgione