### PR TITLE
Bug fix in the get.var.mean.freqs function.

### DIFF
--- a/R/model.comparison.R
+++ b/R/model.comparison.R
@@ -251,7 +251,7 @@ make.data.partitions <- function(n.reps,freqs,train.prop){
 
 get.var.mean.freqs <- function(freqs){
 	varMeanFreqs <- mean(0.5 * colMeans(freqs - 0.5, na.rm = TRUE)^2 + 
-	            		 0.5 * colMeans(0.5 - freqs, na.rm = TRUE)^2)
+	            		 0.5 * colMeans(0.5 - freqs, na.rm = TRUE)^2, na.rm=TRUE)
 	return(varMeanFreqs)
 }
 


### PR DESCRIPTION
get.var.mean.freqs function in the file model.comparison.R did not pass the na.rm=TRUE parameter in the call to the mean function, which produced varMeanFreqs value of NaN in any dataset with at least one NaN.