### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,8 @@ Encoding: UTF-8
 LazyData: true
 ByteCompile: true
 Depends: R (>= 3.4.0), Rcpp (>= 0.12.0), methods
-Imports: rstan (>= 2.18.1), rstantools (>= 1.5.0), caroline, gtools, foreach, parallel, doParallel
-LinkingTo: StanHeaders (>= 2.18.0), rstan (>= 2.18.1), BH (>= 1.66.0), Rcpp (>= 0.12.0), RcppEigen (>= 0.3.3.3.0), RcppParallel (>= 5.0.1)
+Imports: rstan (>= 2.26.0), rstantools (>= 1.5.0), caroline, gtools, foreach, parallel, doParallel
+LinkingTo: StanHeaders (>= 2.26.0), rstan (>= 2.26.0), BH (>= 1.66.0), Rcpp (>= 0.12.0), RcppEigen (>= 0.3.3.3.0), RcppParallel (>= 5.0.1)
 SystemRequirements: GNU make
 NeedsCompilation: yes
 RoxygenNote: 7.2.3

--- a/inst/stan/multiK.stan
+++ b/inst/stan/multiK.stan
@@ -10,7 +10,7 @@ functions {
 		parCov += gamma + Nug_mat;
 		return parCov;	
 	}
-	matrix make_w_matrix(int N, int K, vector[] w){
+	matrix make_w_matrix(int N, int K, array[] vector w){
 		matrix[N,K] w_mat;
 		for(i in 1:N){
 			w_mat[i] = to_row_vector(w[i]);
@@ -35,7 +35,7 @@ parameters {
 	positive_ordered[K] phi;				// shared drift effect in layer k
 	real<lower=0> gamma;				// covariance between all layers
   	vector<lower=0>[N] nugget; 			// sample-specific variance (allele sampling error + sample-specific drift)
-	simplex[K]    w[N];    				// every sample (N in total) has a K simplex (i.e. K layers)
+	array[N] simplex[K]    w;    				// every sample (N in total) has a K simplex (i.e. K layers)
 }
 transformed parameters {
 	matrix[N,N] parCov;					// this specifies the parametric, admixed covariance matrix

--- a/inst/stan/space_multiK.stan
+++ b/inst/stan/space_multiK.stan
@@ -20,7 +20,7 @@ functions {
 		parCov += gamma + Nug_mat;
 		return parCov;	
 	}
-	matrix make_w_matrix(int N, int K, vector[] w){
+	matrix make_w_matrix(int N, int K, array[] vector w){
 		matrix[N,K] w_mat;
 		for(i in 1:N){
 			w_mat[i] = to_row_vector(w[i]);
@@ -48,7 +48,7 @@ parameters {
 	vector<lower=0, upper=2>[K]  alpha2;					// exponential slope parameter in the parametric covariance in layer k
 	positive_ordered[K] phi;									// shared drift effect in layer k
   	vector<lower=0>[N] nugget; 								// sample-specific variance (allele sampling error + sample-specific drift)
-	simplex[K]    w[N];    									// every sample (N in total) has a K simplex (i.e. K layers)
+	array[N] simplex[K]    w;    									// every sample (N in total) has a K simplex (i.e. K layers)
 	real<lower=0> gamma;
 }
 transformed parameters {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
