### PR TITLE
Relax numerical precision for covariance matrix symmetry check

### DIFF
--- a/R/model.comparison.R
+++ b/R/model.comparison.R
@@ -288,8 +288,8 @@ xval.make.data.block <- function(K, data.partition, coords, spatial, geoDist = N
 check.data.partitions.covmats <- function(args){
 	data.list1 <- lapply(args[["data.partitions"]],function(x){x[[1]]$data})
 	data.list2 <- lapply(args[["data.partitions"]],function(x){x[[2]]$data})
-	if(!all(unlist(lapply(data.list1,function(x){isSymmetric(x, tol = 1e-10)}))) |
-	   !all(unlist(lapply(data.list2,function(x){isSymmetric(x, tol = 1e-10)})))){
+	if(!all(unlist(lapply(data.list1,function(x){isSymmetric(x)}))) |
+	   !all(unlist(lapply(data.list2,function(x){isSymmetric(x)})))){
 		stop("\nyou must specify symmetric matrices for the \"data\" elements of the data partitions list\n\n")
 	}	
 	if(any(unlist(lapply(data.list1,function(x){any(is.na(x))}))) |

--- a/R/model.comparison.R
+++ b/R/model.comparison.R
@@ -288,8 +288,8 @@ xval.make.data.block <- function(K, data.partition, coords, spatial, geoDist = N
 check.data.partitions.covmats <- function(args){
 	data.list1 <- lapply(args[["data.partitions"]],function(x){x[[1]]$data})
 	data.list2 <- lapply(args[["data.partitions"]],function(x){x[[2]]$data})
-	if(!all(unlist(lapply(data.list1,function(x){isSymmetric(x)}))) |
-	   !all(unlist(lapply(data.list2,function(x){isSymmetric(x)})))){
+	if(!all(unlist(lapply(data.list1,function(x){isSymmetric(x, tol = 1e-10)}))) |
+	   !all(unlist(lapply(data.list2,function(x){isSymmetric(x, tol = 1e-10)})))){
 		stop("\nyou must specify symmetric matrices for the \"data\" elements of the data partitions list\n\n")
 	}	
 	if(any(unlist(lapply(data.list1,function(x){any(is.na(x))}))) |

--- a/R/run.conStruct.R
+++ b/R/run.conStruct.R
@@ -307,7 +307,7 @@ calc.covariance <- function(freqs){
 									(1/2) * outer( colMeans(x,na.rm=TRUE), 1-colMeans(x,na.rm=TRUE), "*" ) -
 									(1/2) * outer(1-colMeans(x,na.rm=TRUE), colMeans(x,na.rm=TRUE), "*") + 1/4
 	diag(allelic.covariance) <- 0.25
-	return(allelic.covariance)
+	return((allelic.covariance + t(allelic.covariance))/2)
 }
 
 pos.def.check <- function(obsCov){


### PR DESCRIPTION
**Behavior:**
The cross validation function sometimes gives an error (below) when checking for symmetry of the covariance matrices from each CV fold. The error seems more common for large genotype inputs (and for randomly generated allele frequencies).

**Error message:**
```
Error in check.data.partitions.covmats(args) : 
you must specify symmetric matrices for the "data" elements of the data partitions list
```

**Example:**
```
set.seed(123)
m=1000
n=10
locs = matrix(runif(2*n), nrow=n)
dists = distm(locs, fun = distHaversine)
freqs = matrix(runif(m*n), nrow=n)
x.validation(train.prop = 0.9,
                     n.reps = 8,
                     K = 1:6,
                     freqs = freqs,
                     data.partitions = NULL,
                     geoDist = dists,
                     coords = locs,
                     prefix = "temp",
                     n.iter = 1e3,
                     make.figs = TRUE,
                     save.files = FALSE,
                     parallel = FALSE,
                     n.nodes = NULL)
```
The offending values can be as close as:
-0.0039732048102367745
-0.0039732048102368300

**Fix:**
`isSymmetric()` takes a tolerance argument with default `100 * .Machine$double.eps` (= 2.220446e-16). I replaced this with 1e-10 which seems plenty precise and works for several iterations of the above example.

Don't know if it would also be good to copy the upper triangle onto the lower triangle of each covariance matrix?

